### PR TITLE
Create conferences issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/conferences.md
+++ b/.github/ISSUE_TEMPLATE/conferences.md
@@ -1,0 +1,27 @@
+---
+name: Conference
+about: Submit a conference for the Enarx project to present to.
+title: Event name - date
+labels: conference
+assignees: ''
+
+---
+
+**Info**
+- Conference / Event URL
+- Any other relevant information
+
+**Dates**
+<!-- Some of these are optional, enter what you can. If the event is over several days, use the YYYY-MM-DD/YYYY-MM-DD date format to represent the range. -->
+- CFP opens:     YYYY-MM-DD
+- CFP closes:    YYYY-MM-DD
+- CFP results:   YYYY-MM-DD
+- Slides due:    YYYY-MM-DD
+- Event:         YYYY-MM-DD
+
+**Location**
+Venue, City, (State,) Country
+
+**CFP**
+URL to the Call for Proposals / Papers:
+-


### PR DESCRIPTION
Create a conferences issue template for the outreach repo.

Pulled over from https://github.com/enarx/enarx/blob/master/.github/ISSUE_TEMPLATE/conferences.md
